### PR TITLE
added info that the Node-Red counter node is required too

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A Node Red flow especially for [RedMatic](https://github.com/hobbyquaker/RedMati
 ## Additional Nodes
 
 For the system information the [Node OS](https://flows.nodered.org/node/node-red-contrib-os) is used.
+Additionally the Node-RED [counter node](https://flows.nodered.org/node/node-red-contrib-counter) is required.
 
 ## Flow
 

--- a/README_DE.md
+++ b/README_DE.md
@@ -14,6 +14,7 @@ Dieser Node Red Flow ist speziell für [RedMatic](https://github.com/hobbyquaker
 
 ## Zusätzliche Nodes
 Für die Systeminformationen wird zusätzlich die [Node OS](https://flows.nodered.org/node/node-red-contrib-os) benötigt.
+Weiterhin wird der Node-Red [counter node](https://flows.nodered.org/node/node-red-contrib-counter) benötigt.
 
 ## Flow
 


### PR DESCRIPTION
I added an info to the read me files that the counter node https://flows.nodered.org/node/node-red-contrib-counter is required to deploy the flow.